### PR TITLE
avoid name compatibility check on references

### DIFF
--- a/compiler/method.go
+++ b/compiler/method.go
@@ -160,9 +160,9 @@ func (p *irMethod) compileType(writer, reader schema.AvroType) error {
 
 func (p *irMethod) compileRef(writer, reader *schema.Reference) error {
 	log("compileRef()\n writer:\n %v\n---\nreader: %v\n---\n", writer, reader)
-	if reader != nil && writer.TypeName.Name != reader.TypeName.Name {
-		return fmt.Errorf("Incompatible types by name: %v %v", reader, writer)
-	}
+	//	if reader != nil && writer.TypeName.Name != reader.TypeName.Name {
+	//		return fmt.Errorf("Incompatible types by name: %v %v", reader, writer)
+	//	}
 
 	switch writer.Def.(type) {
 	case *schema.RecordDefinition:


### PR DESCRIPTION
This matches the behaviour of the Java implementation.
Potentially we could make this an opt-in metadata attribute, as discussed [here](https://github.com/actgardner/gogen-avro/issues/112) but this is easier for now.