### PR TITLE
schema: fix semantics for names in namespaces

### DIFF
--- a/schema/record.go
+++ b/schema/record.go
@@ -146,11 +146,13 @@ func (s *RecordDefinition) Doc() string {
 }
 
 func (s *RecordDefinition) Schema() (string, error) {
-	def, err := s.Definition(make(map[QualifiedName]interface{}))
+	def0, err := s.Definition(make(map[QualifiedName]interface{}))
 	if err != nil {
 		return "", err
 	}
-
+	def := def0.(map[string]interface{})
+	delete(def, "namespace")
+	def["name"] = s.name.String()
 	jsonBytes, err := json.Marshal(def)
 	return string(jsonBytes), err
 }


### PR DESCRIPTION
The spec doesn't make a distinction between the namespace
field and a namespace implied by a full name, so we change
to fix that.

Also, when we ask a record for its schema, we always want to
include the full name because there's no parent
to inherit the namespace from, so fix that too.